### PR TITLE
Add chat history to web app

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,9 @@ from fastapi.staticfiles import StaticFiles
 
 from ia_engine import generate_response
 
+# In-memory chat history
+chat_history: list[dict[str, str]] = []
+
 app = FastAPI()
 
 templates = Jinja2Templates(directory="templates")
@@ -19,6 +22,12 @@ async def read_index(request: Request):
 
 @app.post("/ask")
 async def ask_question(question: str = Form(...)):
-    """Receive a question and return the AI response."""
+    """Receive a question and return the AI response with history."""
+    # Generate assistant response
     response_text = generate_response(question)
-    return JSONResponse({"response": response_text})
+
+    # Update in-memory history
+    chat_history.append({"role": "user", "text": question})
+    chat_history.append({"role": "assistant", "text": response_text})
+
+    return JSONResponse({"response": response_text, "history": chat_history})

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,19 +6,28 @@
 </head>
 <body>
     <h1>Assistant Cadeaux</h1>
+    <div id="chat-box" style="max-height: 300px; overflow-y: auto; border: 1px solid #ccc; padding: 0.5em;"></div>
     <form id="chat-form">
         <input type="text" id="question" name="question" placeholder="Posez votre question" required>
         <button type="submit">Envoyer</button>
     </form>
-    <pre id="response"></pre>
 
     <script>
+    const chatBox = document.getElementById('chat-box');
     document.getElementById('chat-form').addEventListener('submit', async (e) => {
         e.preventDefault();
         const formData = new FormData(e.target);
         const res = await fetch('/ask', { method: 'POST', body: formData });
         const data = await res.json();
-        document.getElementById('response').textContent = data.response;
+        // Rebuild chat history
+        chatBox.innerHTML = '';
+        data.history.forEach(msg => {
+            const p = document.createElement('p');
+            p.textContent = (msg.role === 'user' ? 'Vous: ' : 'IA: ') + msg.text;
+            chatBox.appendChild(p);
+        });
+        chatBox.scrollTop = chatBox.scrollHeight;
+        e.target.reset();
     });
     </script>
 </body>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,8 +12,21 @@ from app.main import app
 client = TestClient(app)
 
 def test_ask_endpoint():
-    """Ensure /ask returns a JSON response with 'response' key."""
+    """Ensure /ask returns a JSON response with 'response' and history."""
     response = client.post('/ask', data={'question': 'test'})
     assert response.status_code == 200
     json_data = response.json()
     assert 'response' in json_data
+    assert 'history' in json_data
+    assert isinstance(json_data['history'], list)
+    assert json_data['history'][-2]['role'] == 'user'
+    assert json_data['history'][-2]['text'] == 'test'
+    assert json_data['history'][-1]['role'] == 'assistant'
+    assert json_data['history'][-1]['text'] == json_data['response']
+
+
+def test_history_persistence():
+    """Ensure chat history grows with each request."""
+    first_len = len(client.post('/ask', data={'question': 'hello'}).json()['history'])
+    second_len = len(client.post('/ask', data={'question': 'again'}).json()['history'])
+    assert second_len == first_len + 2


### PR DESCRIPTION
## Summary
- keep in-memory conversation history for each chat
- display the entire history in the HTML frontend
- adjust tests to cover the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b5d94029c8321ac27a6eacd40c05c